### PR TITLE
feat: clickable watch tabs, remote thumbnails, manual rescan

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -60,6 +60,35 @@ pub fn add_local_watch(
     Ok(watch)
 }
 
+/// Re-run a local watch's cold scan (file enumeration + dedupe). For SSH watches this is a
+/// no-op — the SFTP poller already scans on its own cadence and a one-shot extra pass would
+/// race with it. Errors are swallowed and surfaced via existing event channels.
+#[tauri::command]
+pub async fn rescan_watch(
+    app: AppHandle,
+    state: State<'_, Arc<AppState>>,
+    watch_id: String,
+) -> Result<(), String> {
+    let source = state
+        .watches
+        .lock()
+        .iter()
+        .find(|w| w.id == watch_id)
+        .map(|w| w.source.clone());
+    let Some(source) = source else {
+        return Err(format!("watch {watch_id} not found"));
+    };
+    if let WatchSource::Local { path } = source {
+        let root = PathBuf::from(path);
+        if !root.is_dir() {
+            return Err("watch path is not a directory".into());
+        }
+        let state_clone = state.inner().clone();
+        fs_watcher::cold_scan(&app, &state_clone, &watch_id, &root).await;
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn remove_watch(app: AppHandle, state: State<Arc<AppState>>, watch_id: String) {
     fs_watcher::stop_watch(state.inner(), &watch_id);

--- a/src-tauri/src/fs_watcher.rs
+++ b/src-tauri/src/fs_watcher.rs
@@ -129,7 +129,7 @@ pub fn stop_watch(state: &Arc<AppState>, watch_id: &str) {
     }
 }
 
-async fn cold_scan(app: &AppHandle, state: &Arc<AppState>, watch_id: &str, root: &Path) {
+pub async fn cold_scan(app: &AppHandle, state: &Arc<AppState>, watch_id: &str, root: &Path) {
     let mut found: Vec<(PathBuf, std::fs::Metadata)> = Vec::new();
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
@@ -153,16 +153,9 @@ async fn cold_scan(app: &AppHandle, state: &Arc<AppState>, watch_id: &str, root:
         }
     }
 
-    // Cold-scan filter: only files modified in the last 24h, capped at 50 newest.
-    let now_ms = chrono::Utc::now().timestamp_millis();
-    let day_ago_ms = now_ms - 24 * 60 * 60 * 1000;
-    found.retain(|(_, m)| {
-        m.modified()
-            .ok()
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_millis() as i64 >= day_ago_ms)
-            .unwrap_or(false)
-    });
+    // Cold-scan: take the 50 newest matching files. Older ones still appear in the watch as
+    // they're modified — we just don't backfill the entire history on first-add. No time-window
+    // filter: a project folder can be weeks old and the user still wants to see its renders.
     found.sort_by_key(|(_, m)| {
         m.modified()
             .ok()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::get_state,
             commands::add_local_watch,
+            commands::rescan_watch,
             commands::remove_watch,
             commands::set_follow_latest,
             commands::set_selected,

--- a/src/components/RemoteAssetGate.tsx
+++ b/src/components/RemoteAssetGate.tsx
@@ -43,6 +43,39 @@ export function invalidateRemoteAsset(watchId: string, absPath: string): void {
   cache.delete(cacheKey(watchId, absPath));
 }
 
+/// Read the cached local path for a remote asset, kicking off a fetch on miss. Returns null
+/// while pending or on error — caller decides the fallback (e.g., icon for thumbnails).
+/// Pass `enabled=false` for non-SSH items so the hook is a no-op.
+export function useRemoteAsset(
+  watchId: string,
+  absPath: string,
+  enabled: boolean,
+): string | null {
+  const [, setTick] = useState(0);
+
+  if (!enabled) return null;
+
+  const key = cacheKey(watchId, absPath);
+  const entry = cache.get(key);
+
+  if (!entry) {
+    startFetch(watchId, absPath).then(
+      () => setTick((n) => n + 1),
+      () => setTick((n) => n + 1),
+    );
+    return null;
+  }
+  if (entry.kind === "resolved") return entry.localPath;
+  if (entry.kind === "pending") {
+    entry.promise.then(
+      () => setTick((n) => n + 1),
+      () => setTick((n) => n + 1),
+    );
+    return null;
+  }
+  return null;
+}
+
 export interface RemoteAssetGateProps {
   watchId: string;
   absPath: string;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,21 +8,23 @@ export function Sidebar() {
   const order = useVizStore((s) => s.order);
   const items = useVizStore((s) => s.items);
   const watches = useVizStore((s) => s.watches);
+  const activeWatchId = useVizStore((s) => s.activeWatchId);
   const selectedId = useVizStore((s) => s.selectedId);
   const select = useVizStore((s) => s.select);
 
   const parentRef = useRef<HTMLDivElement>(null);
 
-  // Defense against stale items orphaned from a removed watch: only show items whose
-  // watch_id is in the active watches list. Backend should already filter, but a buggy
-  // viz-history.json shouldn't bleed ghost rows into the UI.
+  // Filter to (a) items whose watch_id is in the active watches list (defense against orphans
+  // from a removed watch) and (b) the focused tab if the user selected one.
   const visibleOrder = useMemo(() => {
     const activeIds = new Set(watches.map((w) => w.id));
     return order.filter((id) => {
       const it = items[id];
-      return it != null && activeIds.has(it.watch_id);
+      if (it == null || !activeIds.has(it.watch_id)) return false;
+      if (activeWatchId && it.watch_id !== activeWatchId) return false;
+      return true;
     });
-  }, [order, items, watches]);
+  }, [order, items, watches, activeWatchId]);
 
   const virtualizer = useVirtualizer({
     count: visibleOrder.length,

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Plus, RefreshCw, Sparkles, Trash2, X, AlertTriangle } from "lucide-react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { FolderOpen, RefreshCw, Server, Sparkles, Trash2, X, AlertTriangle } from "lucide-react";
 import { useVizStore } from "../store/vizStore";
 import { FollowToggle } from "./FollowToggle";
 import { ConnectRemoteDialog } from "./ConnectRemoteDialog";
@@ -9,12 +10,32 @@ import type { Watch, WatchStatus } from "../types";
 export function TopBar() {
   const watches = useVizStore((s) => s.watches);
   const watchStatus = useVizStore((s) => s.watchStatus);
+  const activeWatchId = useVizStore((s) => s.activeWatchId);
+  const setActiveWatchId = useVizStore((s) => s.setActiveWatchId);
   const followLatest = useVizStore((s) => s.followLatest);
   const toggleFollow = useVizStore((s) => s.toggleFollow);
+  const addWatch = useVizStore((s) => s.addWatch);
   const removeWatch = useVizStore((s) => s.removeWatch);
   const clearGalleryStore = useVizStore((s) => s.clearGallery);
 
   const [showRemote, setShowRemote] = useState(false);
+  const [addLocalErr, setAddLocalErr] = useState<string | null>(null);
+
+  const onAddLocal = async () => {
+    setAddLocalErr(null);
+    const path = await open({
+      directory: true,
+      multiple: false,
+      title: "Pick a folder to watch",
+    });
+    if (!path || typeof path !== "string") return;
+    try {
+      const watch = await tauri.addLocalWatch(path);
+      addWatch(watch);
+    } catch (e) {
+      setAddLocalErr(String(e));
+    }
+  };
 
   const onToggleFollow = () => {
     toggleFollow();
@@ -33,11 +54,35 @@ export function TopBar() {
         <span className="text-[13px] font-semibold tracking-wide">Claude Data Viz</span>
       </div>
       <div className="flex-1 flex items-center gap-1.5 overflow-x-auto">
+        {watches.length > 1 && (
+          <button
+            onClick={() => setActiveWatchId(null)}
+            title="Show items from all watches"
+            className={`flex items-center px-2 py-0.5 rounded text-[11px] flex-shrink-0 border ${
+              activeWatchId == null
+                ? "bg-[color:var(--color-accent)]/15 border-[color:var(--color-accent)]/50 text-[color:var(--color-text)]"
+                : "bg-[color:var(--color-surface-2)] border-[color:var(--color-border)] text-[color:var(--color-text-dim)] hover:text-[color:var(--color-text)]"
+            }`}
+          >
+            All
+          </button>
+        )}
         {watches.map((w) => (
           <WatchTab
             key={w.id}
             watch={w}
             status={watchStatus[w.id] ?? null}
+            active={activeWatchId === w.id}
+            onClick={() => {
+              const next = activeWatchId === w.id ? null : w.id;
+              setActiveWatchId(next);
+              // Focusing a tab is the user signaling "show me this folder now" — kick off
+              // a rescan so any files added since the last scan appear without a restart.
+              // No-op for SSH (the SFTP poller handles its own refresh cadence).
+              if (next === w.id && w.source.kind === "local") {
+                tauri.rescanWatch(w.id).catch(() => {});
+              }
+            }}
             onRemove={async () => {
               await tauri.removeWatch(w.id);
               removeWatch(w.id);
@@ -45,14 +90,30 @@ export function TopBar() {
           />
         ))}
         <button
-          onClick={() => setShowRemote(true)}
-          title="Add remote server"
+          onClick={onAddLocal}
+          title="Watch a local folder"
           className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] text-[color:var(--color-text-dim)] hover:text-[color:var(--color-text)] hover:bg-[color:var(--color-surface-2)] border border-transparent hover:border-[color:var(--color-border)] flex-shrink-0"
         >
-          <Plus className="w-3 h-3" />
+          <FolderOpen className="w-3 h-3" />
+          local
+        </button>
+        <button
+          onClick={() => setShowRemote(true)}
+          title="Connect to a remote server"
+          className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] text-[color:var(--color-text-dim)] hover:text-[color:var(--color-text)] hover:bg-[color:var(--color-surface-2)] border border-transparent hover:border-[color:var(--color-border)] flex-shrink-0"
+        >
+          <Server className="w-3 h-3" />
           remote
         </button>
       </div>
+      {addLocalErr && (
+        <span
+          className="text-[11px] text-red-300 truncate max-w-[260px]"
+          title={addLocalErr}
+        >
+          {addLocalErr}
+        </span>
+      )}
       <button
         onClick={onClear}
         title="Clear gallery"
@@ -70,22 +131,40 @@ export function TopBar() {
 function WatchTab({
   watch,
   status,
+  active,
+  onClick,
   onRemove,
 }: {
   watch: Watch;
   status: WatchStatus | null;
+  active: boolean;
+  onClick: () => void;
   onRemove: () => void;
 }) {
+  const label =
+    watch.source.kind === "local"
+      ? watch.source.path
+      : `${watch.source.user}@${watch.source.host}:${watch.source.remote_path}`;
   return (
-    <div className="flex items-center gap-1.5 px-2 py-0.5 rounded text-[11px] bg-[color:var(--color-surface-2)] border border-[color:var(--color-border)] flex-shrink-0">
+    <div
+      className={`flex items-center gap-1.5 px-2 py-0.5 rounded text-[11px] border flex-shrink-0 ${
+        active
+          ? "bg-[color:var(--color-accent)]/15 border-[color:var(--color-accent)]/50"
+          : "bg-[color:var(--color-surface-2)] border-[color:var(--color-border)]"
+      }`}
+    >
       {status && status.kind !== "connected" && (
         <StatusBadge status={status} watchId={watch.id} />
       )}
-      <span className="font-mono text-[color:var(--color-text-dim)] truncate max-w-[280px]">
-        {watch.source.kind === "local"
-          ? watch.source.path
-          : `${watch.source.user}@${watch.source.host}:${watch.source.remote_path}`}
-      </span>
+      <button
+        onClick={onClick}
+        title={active ? "Show all watches" : "Filter sidebar to this watch"}
+        className={`font-mono truncate max-w-[280px] hover:text-[color:var(--color-text)] ${
+          active ? "text-[color:var(--color-text)]" : "text-[color:var(--color-text-dim)]"
+        }`}
+      >
+        {label}
+      </button>
       <button
         onClick={onRemove}
         title="Stop watching"

--- a/src/components/VizCard.tsx
+++ b/src/components/VizCard.tsx
@@ -2,8 +2,10 @@ import { clsx } from "clsx";
 import { formatDistanceToNow } from "date-fns";
 import { MessageSquare } from "lucide-react";
 import { convertFileSrc } from "../lib/tauri";
+import { useVizStore } from "../store/vizStore";
 import type { VizItem } from "../types";
 import { iconForKind, labelForKind, rendersInlineImagePreview } from "../viewers";
+import { useRemoteAsset } from "./RemoteAssetGate";
 
 function basename(p: string): string {
   const parts = p.split("/");
@@ -22,6 +24,19 @@ export function VizCard({
   const Icon = iconForKind(item.kind);
   const isImage = rendersInlineImagePreview(item.kind);
   const isDeleted = item.status === "deleted";
+  const isRemote = useVizStore((s) =>
+    s.watches.find((w) => w.id === item.watch_id)?.source.kind === "ssh",
+  );
+  // For SSH items we can't read abs_path directly — route through the fetch cache. Cache miss
+  // returns null; we fall back to the kind icon until the fetch completes.
+  const remoteLocalPath = useRemoteAsset(item.watch_id, item.abs_path, isRemote && isImage);
+  const thumbSrc = isImage
+    ? isRemote
+      ? remoteLocalPath
+        ? `${convertFileSrc(remoteLocalPath)}?v=${item.mtime}`
+        : null
+      : `${convertFileSrc(item.abs_path)}?v=${item.mtime}`
+    : null;
 
   return (
     <button
@@ -35,9 +50,9 @@ export function VizCard({
       )}
     >
       <div className="w-12 h-12 flex-shrink-0 rounded bg-[color:var(--color-surface-2)] border border-[color:var(--color-border)] overflow-hidden flex items-center justify-center">
-        {isImage ? (
+        {thumbSrc ? (
           <img
-            src={`${convertFileSrc(item.abs_path)}?v=${item.mtime}`}
+            src={thumbSrc}
             alt=""
             className="w-full h-full object-cover"
             loading="lazy"

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -40,6 +40,8 @@ export const tauri = {
     }),
   removeWatch: (watchId: string) =>
     invoke<void>("remove_watch", { watchId }),
+  rescanWatch: (watchId: string) =>
+    invoke<void>("rescan_watch", { watchId }),
   setFollowLatest: (value: boolean) =>
     invoke<void>("set_follow_latest", { value }),
   setSelected: (watchId: string | null, absPath: string | null) =>

--- a/src/store/vizStore.ts
+++ b/src/store/vizStore.ts
@@ -18,6 +18,8 @@ interface State {
   watches: Watch[];
   watchStatus: Record<string, WatchStatus>;
   selectedId: ItemId | null;
+  /// When set, the sidebar filters to items for this watch only. null = show all watches.
+  activeWatchId: string | null;
   followLatest: boolean;
   hydrated: boolean;
 }
@@ -31,6 +33,7 @@ interface Actions {
   evictItem: (e: VizEvicted) => void;
   addWatch: (w: Watch) => void;
   removeWatch: (id: string) => void;
+  setActiveWatchId: (id: string | null) => void;
   setWatchStatus: (id: string, status: WatchStatus) => void;
   select: (id: ItemId | null) => void;
   toggleFollow: () => void;
@@ -50,6 +53,7 @@ export const useVizStore = create<State & Actions>()(
     watches: [],
     watchStatus: {},
     selectedId: null,
+    activeWatchId: null,
     followLatest: true,
     hydrated: false,
 
@@ -146,12 +150,14 @@ export const useVizStore = create<State & Actions>()(
         return {
           watches: s.watches.filter((w) => w.id !== id),
           watchStatus: remainingStatus,
+          activeWatchId: s.activeWatchId === id ? null : s.activeWatchId,
           items: Object.fromEntries(
             Object.entries(s.items).filter(([_, it]) => it.watch_id !== id),
           ),
           order: s.order.filter((k) => !k.startsWith(`${id}::`)),
         };
       }),
+    setActiveWatchId: (id) => set({ activeWatchId: id }),
     setWatchStatus: (id, status) =>
       set((s) => ({ watchStatus: { ...s.watchStatus, [id]: status } })),
 


### PR DESCRIPTION
TopBar:
- + local button (sibling to + remote) opens the OS folder picker inline; first-run picker is no longer the only path to add a watch.
- Watch tabs are now clickable. Click filters the sidebar to that watch's items only; click again (or click All when 2+ watches exist) to clear the filter. The active tab gets the accent border.
- Clicking a local tab triggers rescan_watch — the user's signal of "show me this folder now" picks up files added since the last scan without an app restart. SSH tabs skip the rescan since the SFTP poller handles its own cadence.

Sidebar thumbnails for remote images:
- VizCard previously called convertFileSrc(item.abs_path) directly, which 404s for SSH items because abs_path is remote. New useRemoteAsset hook (in RemoteAssetGate) reads the fetch cache and triggers a background fetch on miss; cache hits render immediately, misses fall back to the kind icon until the fetch resolves.

Cold-scan:
- Drop the 24h mtime filter. The 50-newest cap is enough — a project folder weeks old should still surface its renders when the user watches it.

Backend:
- New rescan_watch command (local watches only). cold_scan made pub.
- Store gains activeWatchId + setActiveWatchId.