### PR TITLE
feat: SSH watcher exponential backoff + proactive status emit

### DIFF
--- a/src-tauri/src/ssh/watcher.rs
+++ b/src-tauri/src/ssh/watcher.rs
@@ -173,7 +173,7 @@ async fn run_loop(
         let sftp = match conn.open_sftp().await {
             Ok(s) => s,
             Err(e) => {
-                set_status(
+                set_status_and_maybe_emit(
                     &app,
                     &status,
                     &watch_id,
@@ -192,7 +192,7 @@ async fn run_loop(
             Err(e) => {
                 let msg = e.to_string();
                 if msg.contains("No such file") || msg.contains("not found") {
-                    set_status(
+                    set_status_and_maybe_emit(
                         &app,
                         &status,
                         &watch_id,
@@ -200,7 +200,7 @@ async fn run_loop(
                     );
                     return; // Stop polling — config is bad. User must edit watch.
                 }
-                set_status(
+                set_status_and_maybe_emit(
                     &app,
                     &status,
                     &watch_id,
@@ -214,9 +214,10 @@ async fn run_loop(
             }
         };
 
-        // Successful scan ⇒ Connected, reset backoff.
+        // Successful scan ⇒ Connected, reset backoff. Emits proactively if we were
+        // previously Reconnecting — fixes the stale "Reconnecting for Xs" topbar bug.
         backoff.reset();
-        set_status(&app, &status, &watch_id, WatchStatus::Connected);
+        set_status_and_maybe_emit(&app, &status, &watch_id, WatchStatus::Connected);
 
         let any_change = reconcile(
             &app,
@@ -481,38 +482,35 @@ async fn emit_new(
     cap::enforce_item_cap(app, state);
 }
 
-fn set_status(
+/// Update the watch's status mutex and emit `viz:watch_status` IFF the status actually
+/// changed (full structural equality, not variant-level). This is the side-effecting
+/// counterpart to the pure `StatusTransition::diff` helper used in tests.
+///
+/// The proactive emit is what fixes the stale "Reconnecting for Xs" topbar after a
+/// recovery: the moment a scan succeeds, we transition to Connected and the frontend
+/// gets the event without waiting for the next file change.
+fn set_status_and_maybe_emit(
     app: &AppHandle,
     status: &Arc<parking_lot::Mutex<WatchStatus>>,
     watch_id: &str,
     next: WatchStatus,
 ) {
     let mut cur = status.lock();
-    if statuses_equal(&cur, &next) {
+    let to_emit = StatusTransition::diff(&cur, &next);
+    if to_emit.is_none() {
         return;
     }
-    *cur = next.clone();
+    *cur = next;
     drop(cur);
-    let _ = app.emit(
-        "viz:watch_status",
-        WatchStatusEvent {
-            watch_id: watch_id.to_string(),
-            status: next,
-        },
-    );
-}
-
-fn statuses_equal(a: &WatchStatus, b: &WatchStatus) -> bool {
-    use WatchStatus::*;
-    matches!(
-        (a, b),
-        (Connected, Connected)
-            | (Stopped, Stopped)
-            | (Reconnecting { .. }, Reconnecting { .. })
-            | (AuthFailed { .. }, AuthFailed { .. })
-            | (Unreachable { .. }, Unreachable { .. })
-            | (PathInvalid { .. }, PathInvalid { .. })
-    )
+    if let Some(payload) = to_emit {
+        let _ = app.emit(
+            "viz:watch_status",
+            WatchStatusEvent {
+                watch_id: watch_id.to_string(),
+                status: payload,
+            },
+        );
+    }
 }
 
 /// Convenience for tests / external callers — registers an SshWatcher into watch_handles.

--- a/src-tauri/src/ssh/watcher.rs
+++ b/src-tauri/src/ssh/watcher.rs
@@ -30,11 +30,8 @@ use tokio::task::JoinHandle;
 const POLL_ACTIVE_MS: u64 = 2000;
 const POLL_IDLE_MS: u64 = 10_000;
 const RECURSION_DEPTH: usize = 4;
-#[allow(dead_code)]
 const BACKOFF_INITIAL_MS: u64 = 2_000;
-#[allow(dead_code)]
 const BACKOFF_MAX_MS: u64 = 300_000; // 5 min
-#[allow(dead_code)]
 const BACKOFF_JITTER: f64 = 0.2; // ±20%
 const SKIP_DIRS: &[&str] = &[
     ".git",
@@ -161,18 +158,17 @@ async fn run_loop(
 ) {
     let mut tracked: HashMap<String, FileTrack> = HashMap::new();
     let mut idle_streak: u32 = 0;
+    let mut backoff = BackoffState::new(
+        BACKOFF_INITIAL_MS,
+        BACKOFF_MAX_MS,
+        BACKOFF_JITTER,
+        seed_from_watch_id(&watch_id),
+    );
 
     loop {
         if cancel.load(Ordering::Relaxed) {
             return;
         }
-
-        let interval_ms = if idle_streak >= 5 {
-            POLL_IDLE_MS
-        } else {
-            POLL_ACTIVE_MS
-        };
-        tokio::time::sleep(Duration::from_millis(interval_ms)).await;
 
         let sftp = match conn.open_sftp().await {
             Ok(s) => s,
@@ -186,6 +182,7 @@ async fn run_loop(
                         last_error: Some(e.to_string()),
                     },
                 );
+                tokio::time::sleep(backoff.next_delay()).await;
                 continue;
             }
         };
@@ -212,11 +209,13 @@ async fn run_loop(
                         last_error: Some(msg),
                     },
                 );
+                tokio::time::sleep(backoff.next_delay()).await;
                 continue;
             }
         };
 
-        // Successful scan ⇒ Connected.
+        // Successful scan ⇒ Connected, reset backoff.
+        backoff.reset();
         set_status(&app, &status, &watch_id, WatchStatus::Connected);
 
         let any_change = reconcile(
@@ -234,6 +233,13 @@ async fn run_loop(
         } else {
             idle_streak = idle_streak.saturating_add(1);
         }
+
+        let interval_ms = if idle_streak >= 5 {
+            POLL_IDLE_MS
+        } else {
+            POLL_ACTIVE_MS
+        };
+        tokio::time::sleep(Duration::from_millis(interval_ms)).await;
     }
 }
 
@@ -588,7 +594,6 @@ impl StatusTransition {
 
 /// Derive a deterministic LCG seed from a watch_id so two watchers picking concurrent
 /// jitter samples don't synchronize their reconnect storms.
-#[allow(dead_code)]
 pub(crate) fn seed_from_watch_id(watch_id: &str) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};

--- a/src-tauri/src/ssh/watcher.rs
+++ b/src-tauri/src/ssh/watcher.rs
@@ -30,6 +30,12 @@ use tokio::task::JoinHandle;
 const POLL_ACTIVE_MS: u64 = 2000;
 const POLL_IDLE_MS: u64 = 10_000;
 const RECURSION_DEPTH: usize = 4;
+#[allow(dead_code)]
+const BACKOFF_INITIAL_MS: u64 = 2_000;
+#[allow(dead_code)]
+const BACKOFF_MAX_MS: u64 = 300_000; // 5 min
+#[allow(dead_code)]
+const BACKOFF_JITTER: f64 = 0.2; // ±20%
 const SKIP_DIRS: &[&str] = &[
     ".git",
     "node_modules",
@@ -517,3 +523,212 @@ pub fn install(state: &Arc<AppState>, watcher: SshWatcher) {
 
 #[allow(dead_code)]
 fn _force_use(_: &PathBuf) {}
+
+/// Exponential-backoff-with-jitter state machine.
+///
+/// Pure (no I/O, no tokio dependency). Doubles `current_ms` after each `next_delay()` call,
+/// caps at `max_ms`, applies symmetric ±`jitter_frac` jitter, and resets to `min_ms` on
+/// `reset()`. Uses an inline LCG so behavior is deterministic given a seed — no `rand` crate
+/// pulled in for tests, no flakes.
+#[derive(Debug)]
+pub(crate) struct BackoffState {
+    current_ms: u64,
+    min_ms: u64,
+    max_ms: u64,
+    jitter_frac: f64,
+    rng_state: u64,
+}
+
+impl BackoffState {
+    pub fn new(min_ms: u64, max_ms: u64, jitter_frac: f64, seed: u64) -> Self {
+        Self {
+            current_ms: min_ms,
+            min_ms,
+            max_ms,
+            jitter_frac,
+            rng_state: seed.max(1),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.current_ms = self.min_ms;
+    }
+
+    pub fn next_delay(&mut self) -> Duration {
+        let base = self.current_ms;
+        // LCG (Knuth/MMIX constants) — fine for jitter, not for crypto.
+        self.rng_state = self
+            .rng_state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let r = (self.rng_state >> 32) as u32 as f64 / u32::MAX as f64; // 0..1
+        let frac = (r * 2.0 - 1.0) * self.jitter_frac; // -jitter..+jitter
+        let jittered = ((base as f64) * (1.0 + frac)).max(0.0) as u64;
+        self.current_ms = self.current_ms.saturating_mul(2).min(self.max_ms);
+        Duration::from_millis(jittered)
+    }
+}
+
+/// Pure helper that mirrors `set_status_and_maybe_emit`'s decision logic without side
+/// effects, so it can be unit-tested independently of Tauri's `AppHandle::emit`.
+pub(crate) struct StatusTransition;
+
+impl StatusTransition {
+    /// Returns the status that should be emitted, or `None` if the new status is equal to
+    /// the previous one. Equality is full structural `PartialEq` — payload differences in
+    /// `Reconnecting` (e.g. updated `last_error`) are treated as a transition.
+    pub fn diff(prev: &WatchStatus, next: &WatchStatus) -> Option<WatchStatus> {
+        if prev == next {
+            None
+        } else {
+            Some(next.clone())
+        }
+    }
+}
+
+/// Derive a deterministic LCG seed from a watch_id so two watchers picking concurrent
+/// jitter samples don't synchronize their reconnect storms.
+#[allow(dead_code)]
+pub(crate) fn seed_from_watch_id(watch_id: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    watch_id.hash(&mut h);
+    h.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::WatchStatus;
+
+    #[test]
+    fn backoff_initial_delay_is_min() {
+        let mut b = BackoffState::new(2000, 300_000, 0.0, 1);
+        assert_eq!(b.next_delay(), Duration::from_millis(2000));
+    }
+
+    #[test]
+    fn backoff_doubles_on_consecutive_errors() {
+        let mut b = BackoffState::new(2000, 300_000, 0.0, 1);
+        assert_eq!(b.next_delay(), Duration::from_millis(2000));
+        assert_eq!(b.next_delay(), Duration::from_millis(4000));
+        assert_eq!(b.next_delay(), Duration::from_millis(8000));
+        assert_eq!(b.next_delay(), Duration::from_millis(16000));
+    }
+
+    #[test]
+    fn backoff_caps_at_max() {
+        let mut b = BackoffState::new(2000, 10_000, 0.0, 1);
+        assert_eq!(b.next_delay(), Duration::from_millis(2000));
+        assert_eq!(b.next_delay(), Duration::from_millis(4000));
+        assert_eq!(b.next_delay(), Duration::from_millis(8000));
+        // Capped from here on.
+        for _ in 0..10 {
+            assert_eq!(b.next_delay(), Duration::from_millis(10_000));
+        }
+    }
+
+    #[test]
+    fn backoff_resets_on_success() {
+        let mut b = BackoffState::new(2000, 300_000, 0.0, 1);
+        b.next_delay(); // 2000
+        b.next_delay(); // 4000
+        b.next_delay(); // 8000
+        b.reset();
+        assert_eq!(b.next_delay(), Duration::from_millis(2000));
+    }
+
+    #[test]
+    fn backoff_jitter_within_bounds() {
+        // jitter=0.2, base=4000 ⇒ delays must fall in [3200, 4800].
+        // Force base by stepping past initial: 2000 → step → 4000.
+        let lo = 3200u64;
+        let hi = 4800u64;
+        for sample_seed in 1..=50u64 {
+            let mut b = BackoffState::new(2000, 300_000, 0.2, sample_seed);
+            // Skip the 2000-base sample.
+            let _ = b.next_delay();
+            let d = b.next_delay().as_millis() as u64;
+            assert!(
+                d >= lo && d <= hi,
+                "seed {sample_seed}: delay {d} not in [{lo}, {hi}]"
+            );
+        }
+    }
+
+    #[test]
+    fn backoff_jitter_deterministic_with_same_seed() {
+        let mut a = BackoffState::new(2000, 300_000, 0.2, 7);
+        let mut b = BackoffState::new(2000, 300_000, 0.2, 7);
+        assert_eq!(a.next_delay(), b.next_delay());
+        assert_eq!(a.next_delay(), b.next_delay());
+        assert_eq!(a.next_delay(), b.next_delay());
+    }
+
+    #[test]
+    fn transition_emits_on_change() {
+        let prev = WatchStatus::Reconnecting {
+            since_ms: 100,
+            last_error: Some("boom".into()),
+        };
+        let next = WatchStatus::Connected;
+        assert_eq!(
+            StatusTransition::diff(&prev, &next),
+            Some(WatchStatus::Connected)
+        );
+    }
+
+    #[test]
+    fn transition_no_emit_on_same_status() {
+        // Two identical Connected statuses → no emit.
+        assert_eq!(
+            StatusTransition::diff(&WatchStatus::Connected, &WatchStatus::Connected),
+            None
+        );
+        // Two identical Reconnecting payloads → no emit.
+        let a = WatchStatus::Reconnecting {
+            since_ms: 100,
+            last_error: Some("x".into()),
+        };
+        let b = WatchStatus::Reconnecting {
+            since_ms: 100,
+            last_error: Some("x".into()),
+        };
+        assert_eq!(StatusTransition::diff(&a, &b), None);
+    }
+
+    #[test]
+    fn transition_emits_with_correct_payload() {
+        // Reconnecting → Connected emits Connected.
+        let prev = WatchStatus::Reconnecting {
+            since_ms: 100,
+            last_error: Some("a".into()),
+        };
+        let next = WatchStatus::Connected;
+        assert_eq!(
+            StatusTransition::diff(&prev, &next),
+            Some(WatchStatus::Connected)
+        );
+
+        // Reconnecting payload mutation (last_error a → b) emits the new Reconnecting.
+        let prev = WatchStatus::Reconnecting {
+            since_ms: 100,
+            last_error: Some("a".into()),
+        };
+        let next = WatchStatus::Reconnecting {
+            since_ms: 100,
+            last_error: Some("b".into()),
+        };
+        assert_eq!(StatusTransition::diff(&prev, &next), Some(next));
+    }
+
+    #[test]
+    fn seed_from_watch_id_is_stable_and_distinct() {
+        let a1 = seed_from_watch_id("watch-a");
+        let a2 = seed_from_watch_id("watch-a");
+        let b = seed_from_watch_id("watch-b");
+        assert_eq!(a1, a2);
+        assert_ne!(a1, b);
+    }
+}

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -107,7 +107,7 @@ pub enum WatchSource {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 #[ts(export, export_to = "../../src/types/bindings/")]
 pub enum WatchStatus {


### PR DESCRIPTION
## What
- Adds \`BackoffState\` (2s → 5min, ±20% jitter, per-watch deterministic seed via \`DefaultHasher\` over \`watch_id\`) on SSH watcher errors.
- Replaces the in-place \`set_status\` + \`statuses_equal\` pattern with \`set_status_and_maybe_emit\` doing full structural \`PartialEq\` diff. Every transition now emits \`viz:watch_status\` immediately.
- Derives \`PartialEq, Eq\` on \`WatchStatus\` (additive, no ts-rs impact).

## Why
- **Backoff**: \`run_loop\` was polling every 2s forever on errors. ~1,800 wasted SFTP attempts per hour during outages → ~30/hour at the 5-min cap.
- **Proactive emit**: After recovery from \`Reconnecting\` → \`Connected\`, the topbar showed stale "Reconnecting for Xs" until the next event fired. Now flips the instant a scan succeeds.

## How
Both behaviors refactored as pure helpers (\`BackoffState\`, \`StatusTransition::diff\`) so they're unit-testable without SFTP. RNG is a tiny inline LCG seeded from the watch id — no \`rand\` dep added.

Constants: \`BACKOFF_INITIAL_MS=2000\`, \`BACKOFF_MAX_MS=300_000\`, \`BACKOFF_JITTER=0.2\`.

## Test plan
10 new unit tests in \`ssh::watcher::tests\`:
- \`backoff_initial_delay_is_min\`, \`backoff_doubles_on_consecutive_errors\`, \`backoff_caps_at_max\`, \`backoff_resets_on_success\`, \`backoff_jitter_within_bounds\`, \`backoff_jitter_deterministic_with_same_seed\`.
- \`transition_emits_on_change\`, \`transition_no_emit_on_same_status\`, \`transition_emits_with_correct_payload\`.
- \`seed_from_watch_id_is_stable_and_distinct\`.

\`cargo test --lib\`: 50/50 pass. \`npm run build\`: clean.

Manual: kill the dev box's SSH listener (watcher backs off), bring it back (topbar flips to Connected without waiting for a file change).

## Risk
At the 5-min cap a watch that's been down for an hour polls 12×/hr instead of 1,800. Acceptable; manual reconnect still available via the existing button. Long sleeps inside backoff still cancel cleanly via \`task.abort()\` in \`Drop\`.