### PR TITLE
fix: convert two production .expect() panic sites to graceful failure

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-opener",
  "tauri-plugin-store",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "ts-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ async-trait = "0.1"
 ssh2-config = "0.5"
 filetime = "0.2"
 
+[dev-dependencies]
+tempfile = "3"
+
 [profile.release]
 panic = "abort"
 codegen-units = 1

--- a/src-tauri/src/fs_watcher.rs
+++ b/src-tauri/src/fs_watcher.rs
@@ -167,7 +167,9 @@ pub async fn cold_scan(app: &AppHandle, state: &Arc<AppState>, watch_id: &str, r
     let take_from = found.len().saturating_sub(50);
     let mut any_new = false;
     for (path, meta) in found.into_iter().skip(take_from) {
-        let fresh = build_item(watch_id, root, &path, &meta);
+        let Some(fresh) = build_item(watch_id, root, &path, &meta) else {
+            continue;
+        };
         let key = (watch_id.to_string(), fresh.abs_path.clone());
         let (merged, was_present) = upsert_preserving_enrichment(state, key, fresh);
         let is_new = !was_present;
@@ -253,7 +255,13 @@ async fn process_event(
             if meta.len() != size1 {
                 return;
             }
-            let fresh = build_item(watch_id, root, &path, &meta);
+            let Some(fresh) = build_item(watch_id, root, &path, &meta) else {
+                eprintln!(
+                    "warn: fs_watcher: build_item rejected unexpected path {}",
+                    path.display()
+                );
+                return;
+            };
             let key = (watch_id.to_string(), fresh.abs_path.clone());
             let (merged, was_present) = upsert_preserving_enrichment(state, key, fresh);
             if was_present {
@@ -302,7 +310,13 @@ async fn handle_remove(app: &AppHandle, state: &Arc<AppState>, watch_id: &str, p
     }
 }
 
-fn build_item(watch_id: &str, root: &Path, path: &Path, meta: &std::fs::Metadata) -> VizItem {
+fn build_item(
+    watch_id: &str,
+    root: &Path,
+    path: &Path,
+    meta: &std::fs::Metadata,
+) -> Option<VizItem> {
+    let kind = VizKind::from_path(path)?;
     let abs = path.to_string_lossy().into_owned();
     let rel = path
         .strip_prefix(root)
@@ -318,12 +332,11 @@ fn build_item(watch_id: &str, root: &Path, path: &Path, meta: &std::fs::Metadata
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_millis() as i64)
         .unwrap_or_else(|| Utc::now().timestamp_millis());
-    VizItem {
+    Some(VizItem {
         watch_id: watch_id.to_string(),
         abs_path: abs,
         rel_path: rel,
-        kind: VizKind::from_path(path)
-            .expect("watcher already filtered to known kinds via VizKind::from_path"),
+        kind,
         size: meta.len(),
         mtime,
         prompt: None,
@@ -331,7 +344,7 @@ fn build_item(watch_id: &str, root: &Path, path: &Path, meta: &std::fs::Metadata
         session_id: None,
         cwd: None,
         status: VizStatus::Active,
-    }
+    })
 }
 
 fn is_skippable_dir(path: &Path) -> bool {

--- a/src-tauri/src/fs_watcher.rs
+++ b/src-tauri/src/fs_watcher.rs
@@ -362,3 +362,31 @@ fn is_skippable_dir(path: &Path) -> bool {
         )
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn build_item_returns_none_for_unknown_extension() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("notes.txt");
+        fs::write(&path, b"hello").expect("write txt");
+        let meta = fs::metadata(&path).expect("metadata");
+        assert!(build_item("watch-1", dir.path(), &path, &meta).is_none());
+    }
+
+    #[test]
+    fn build_item_returns_some_for_png() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("plot.png");
+        fs::write(&path, b"\x89PNG\r\n").expect("write png");
+        let meta = fs::metadata(&path).expect("metadata");
+        let item = build_item("watch-1", dir.path(), &path, &meta).expect("some item");
+        assert_eq!(item.kind, VizKind::Png);
+        assert_eq!(item.watch_id, "watch-1");
+        assert_eq!(item.rel_path, "plot.png");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ const HISTORY_FLUSH_INTERVAL_MS: u64 = 500;
 pub fn run() {
     let app_state = AppState::new();
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
@@ -145,9 +145,12 @@ pub fn run() {
             commands::forget_recent_remote,
             commands::update_remote_watch_path,
             commands::list_remote_dirs,
-        ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        ]);
+
+    if let Err(e) = builder.run(tauri::generate_context!()) {
+        eprintln!("fatal: tauri runtime exited with error: {e:#}");
+        std::process::exit(1);
+    }
 }
 
 /// Returns the number of persisted items that were dropped (orphaned from a removed watch, or


### PR DESCRIPTION
## What
- \`fs_watcher.rs\`: \`build_item\` signature changes from \`-> VizItem\` to \`-> Option<VizItem>\`. Removes \`VizKind::from_path(path).expect(...)\` panic. Both callers updated with \`let Some(...) else\`.
- \`lib.rs\`: \`tauri::Builder::run(...).expect(...)\` becomes \`if let Err(e) = ... { eprintln!("fatal: ..."); std::process::exit(1); }\` — non-zero exit + full source chain via \`{e:#}\`.

## Why
Both call sites had latent panics. \`build_item\`'s comment claimed callers always pre-filter — true today, but the type system didn't enforce it. The Tauri \`.expect()\` would unwind through async runtime cleanup on any startup failure, producing useless backtraces instead of an actionable error line.

The full audit found exactly these two production sites — five other \`.unwrap()\`s in the codebase are all inside \`#[cfg(test)]\` test modules (idiomatic).

## Test plan
2 new unit tests in \`fs_watcher::tests\`:
- \`build_item_returns_none_for_unknown_extension\` (\`.txt\` → None; was a panic before).
- \`build_item_returns_some_for_png\` (happy path lock-in).

\`cargo test --lib fs_watcher\`: 2/2 pass. \`cargo build --release\`: clean. \`npm run build\`: clean.

\`lib.rs\` has no good unit-test seam — manual smoke verified via release build.

## Files
- \`src-tauri/src/fs_watcher.rs\`
- \`src-tauri/src/lib.rs\`
- \`src-tauri/Cargo.toml\` (+\`tempfile = "3"\` dev-dep)
- \`src-tauri/Cargo.lock\` (regenerated)

## Risk
None meaningful. \`build_item\` is private with two callers in the same module. \`std::process::exit(1)\` skips destructors but matches existing panic semantics on release. Logging deps not added here — if PR6 (diagnostic logging) lands first, the two new \`eprintln!\` lines can be swept to \`tracing::warn!\` / \`error!\` later.