### PR TITLE
chore: structured logging across swallowed-error sites

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -628,6 +628,9 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-test",
  "ts-rs",
  "uuid",
 ]
@@ -2739,6 +2742,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,6 +2917,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4587,6 +4608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5368,6 +5398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5664,6 +5703,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5857,6 +5947,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,14 +42,11 @@ filetime = "0.2"
 hmac = "0.12"
 sha1 = "0.10"
 data-encoding = "2"
-
-[dev-dependencies]
-tempfile = "3"
-
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
+tempfile = "3"
 tracing-test = "0.2"
 
 [profile.release]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,12 @@ data-encoding = "2"
 [dev-dependencies]
 tempfile = "3"
 
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tracing-test = "0.2"
+
 [profile.release]
 panic = "abort"
 codegen-units = 1

--- a/src-tauri/src/cap.rs
+++ b/src-tauri/src/cap.rs
@@ -34,12 +34,16 @@ pub fn enforce_item_cap(app: &AppHandle, state: &Arc<AppState>) {
         mark_history_dirty(state);
     }
     for (watch_id, abs_path) in evicted {
-        let _ = app.emit(
+        let watch_id_for_log = watch_id.clone();
+        let abs_path_for_log = abs_path.clone();
+        if let Err(err) = app.emit(
             "viz:evicted",
             VizEvicted {
                 watch_id,
                 abs_path,
             },
-        );
+        ) {
+            tracing::warn!(?err, watch_id = %watch_id_for_log, abs_path = %abs_path_for_log, "cap: emit viz:evicted failed");
+        }
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -712,7 +712,7 @@ pub async fn fetch_remote_file(
         )
         .await
         {
-            eprintln!("ssh: html sibling fetch failed: {e}");
+            tracing::warn!(err = %e, %abs_path, "commands: html sibling fetch failed");
         }
     }
 
@@ -870,13 +870,16 @@ pub async fn update_remote_watch_path(
     if !stale_paths.is_empty() {
         mark_history_dirty(state.inner());
         for p in stale_paths {
-            let _ = app.emit(
+            let abs_path_for_log = p.clone();
+            if let Err(err) = app.emit(
                 "viz:gone",
                 VizGone {
                     watch_id: watch_id.clone(),
                     abs_path: p,
                 },
-            );
+            ) {
+                tracing::warn!(?err, %watch_id, abs_path = %abs_path_for_log, "commands: emit viz:gone failed during update_remote_watch_path");
+            }
         }
     }
 

--- a/src-tauri/src/fs_watcher.rs
+++ b/src-tauri/src/fs_watcher.rs
@@ -45,7 +45,7 @@ pub fn start_watch(
         .asset_protocol_scope()
         .allow_directory(&root, true)
     {
-        eprintln!("warn: failed to extend asset protocol scope: {e}");
+        tracing::warn!(err = %e, root = %root.display(), "fs_watcher: failed to extend asset protocol scope");
     }
 
     let (tx, mut rx) = unbounded_channel::<DebounceEventResult>();
@@ -105,7 +105,7 @@ pub fn start_watch(
                     }
                     Err(errors) => {
                         for err in errors {
-                            eprintln!("notify error: {err}");
+                            tracing::warn!(?err, "fs_watcher: notify error");
                         }
                     }
                 }
@@ -175,7 +175,9 @@ pub async fn cold_scan(app: &AppHandle, state: &Arc<AppState>, watch_id: &str, r
         let is_new = !was_present;
         if is_new {
             any_new = true;
-            let _ = app.emit("viz:new", &merged);
+            if let Err(err) = app.emit("viz:new", &merged) {
+                tracing::warn!(?err, abs_path = %merged.abs_path, "fs_watcher: emit viz:new failed (cold scan)");
+            }
             transcript::try_enrich_now(
                 app,
                 state,
@@ -265,7 +267,7 @@ async fn process_event(
             let key = (watch_id.to_string(), fresh.abs_path.clone());
             let (merged, was_present) = upsert_preserving_enrichment(state, key, fresh);
             if was_present {
-                let _ = app.emit(
+                if let Err(err) = app.emit(
                     "viz:updated",
                     VizUpdated {
                         watch_id: watch_id.to_string(),
@@ -273,9 +275,11 @@ async fn process_event(
                         mtime: merged.mtime,
                         size: merged.size,
                     },
-                );
-            } else {
-                let _ = app.emit("viz:new", &merged);
+                ) {
+                    tracing::warn!(?err, abs_path = %merged.abs_path, "fs_watcher: emit viz:updated failed");
+                }
+            } else if let Err(err) = app.emit("viz:new", &merged) {
+                tracing::warn!(?err, abs_path = %merged.abs_path, "fs_watcher: emit viz:new failed");
             }
             transcript::try_enrich_now(
                 app,
@@ -300,13 +304,16 @@ async fn handle_remove(app: &AppHandle, state: &Arc<AppState>, watch_id: &str, p
     let removed = state.items.lock().remove(&key).is_some();
     if removed {
         mark_history_dirty(state);
-        let _ = app.emit(
+        let abs_path = path.to_string_lossy().into_owned();
+        if let Err(err) = app.emit(
             "viz:gone",
             VizGone {
                 watch_id: watch_id.to_string(),
-                abs_path: path.to_string_lossy().into_owned(),
+                abs_path: abs_path.clone(),
             },
-        );
+        ) {
+            tracing::warn!(?err, %abs_path, "fs_watcher: emit viz:gone failed");
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,19 @@ const HISTORY_FLUSH_INTERVAL_MS: u64 = 500;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Idempotent + non-fatal: a Result-returning init means double-calls (e.g. from a future
+    // integration test that exercises run()) won't panic, and a subscriber failure won't kill
+    // the app. RUST_LOG overrides the default. Default keeps our crate at info, everything else
+    // at warn — quiet by default, but our own warnings are visible.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_env("RUST_LOG")
+                .unwrap_or_else(|_| "claude_data_viz=info,warn".into()),
+        )
+        .with_writer(std::io::stderr)
+        .try_init();
+    tracing::info!("claude-data-viz starting");
+
     let app_state = AppState::new();
 
     let builder = tauri::Builder::default()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,7 +93,7 @@ pub fn run() {
                             w.id.clone(),
                             root,
                         ) {
-                            eprintln!("warn: restart local watch {} failed: {}", w.id, e);
+                            tracing::warn!(err = %e, watch_id = %w.id, "lib: restart local watch failed");
                         }
                     }
                     WatchSource::Ssh {
@@ -126,7 +126,7 @@ pub fn run() {
                             )
                             .await
                             {
-                                eprintln!("warn: restart ssh watch {} failed: {}", watch_id, e);
+                                tracing::warn!(err = %e, %watch_id, "lib: restart ssh watch failed");
                             }
                         });
                     }

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -32,7 +32,7 @@ fn default_follow() -> bool {
 fn data_dir(app: &AppHandle) -> Option<PathBuf> {
     let dir = app.path().app_data_dir().ok()?;
     if let Err(e) = std::fs::create_dir_all(&dir) {
-        eprintln!("warn: failed to create app data dir: {e}");
+        tracing::warn!(err = %e, dir = %dir.display(), "persistence: failed to create app data dir");
         return None;
     }
     Some(dir)
@@ -134,17 +134,17 @@ fn write_json<T: Serialize>(path: &Path, value: &T) {
     let bytes = match serde_json::to_vec_pretty(value) {
         Ok(b) => b,
         Err(e) => {
-            eprintln!("warn: serialize {} failed: {e}", path.display());
+            tracing::warn!(err = %e, path = %path.display(), "persistence: serialize failed");
             return;
         }
     };
     // Atomic write: write to .tmp, then rename. Avoids torn reads on crash.
     let tmp = path.with_extension("tmp");
     if let Err(e) = std::fs::write(&tmp, &bytes) {
-        eprintln!("warn: write {} failed: {e}", tmp.display());
+        tracing::warn!(err = %e, tmp = %tmp.display(), "persistence: write tmp failed");
         return;
     }
     if let Err(e) = std::fs::rename(&tmp, path) {
-        eprintln!("warn: rename {} -> {} failed: {e}", tmp.display(), path.display());
+        tracing::warn!(err = %e, tmp = %tmp.display(), path = %path.display(), "persistence: rename tmp -> final failed");
     }
 }

--- a/src-tauri/src/ssh/cache.rs
+++ b/src-tauri/src/ssh/cache.rs
@@ -94,18 +94,24 @@ pub async fn fetch_file(
     let _guard = lock.lock().await;
 
     if cache_hit(&local, remote_mtime_ms, remote_size) {
-        let _ = touch_atime(&local);
+        if let Err(e) = touch_atime(&local) {
+            tracing::warn!(err = %e, path = %local.display(), "ssh_cache: touch_atime failed (cache hit)");
+        }
         return Ok(local);
     }
 
     let sftp = conn.open_sftp().await?;
     download_atomic(&sftp, remote_path, &local).await?;
     set_local_mtime(&local, remote_mtime_ms);
-    let _ = touch_atime(&local);
+    if let Err(e) = touch_atime(&local) {
+        tracing::warn!(err = %e, path = %local.display(), "ssh_cache: touch_atime failed (post-download)");
+    }
 
     // Eviction is best-effort and non-fatal.
     if let Some(root) = local.parent().and_then(|p| p.parent()) {
-        let _ = enforce_cap(root, TOTAL_CAP_BYTES);
+        if let Err(e) = enforce_cap(root, TOTAL_CAP_BYTES) {
+            tracing::warn!(err = %e, root = %root.display(), "ssh_cache: enforce_cap failed");
+        }
     }
     Ok(local)
 }
@@ -173,7 +179,7 @@ pub async fn fetch_html_siblings(
                 bytes += size;
             }
             Err(e) => {
-                eprintln!("ssh: sibling fetch {remote_path} failed: {e}");
+                tracing::warn!(err = %e, %remote_path, "ssh_cache: sibling fetch failed");
             }
         }
     }

--- a/src-tauri/src/ssh/transcript.rs
+++ b/src-tauri/src/ssh/transcript.rs
@@ -35,7 +35,7 @@ pub fn start_poller(
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         if let Err(e) = run(conn, app, state).await {
-            eprintln!("ssh transcript poller exited: {e}");
+            tracing::warn!(err = %e, "ssh_transcript: poller exited with error");
         }
     })
 }
@@ -57,7 +57,7 @@ async fn run(conn: Arc<RemoteConnection>, app: AppHandle, state: Arc<AppState>) 
         let sftp = match conn.open_sftp().await {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("ssh transcript: open_sftp failed: {e}");
+                tracing::warn!(err = %e, "ssh_transcript: open_sftp failed");
                 continue;
             }
         };
@@ -112,7 +112,7 @@ async fn run(conn: Arc<RemoteConnection>, app: AppHandle, state: Arc<AppState>) 
                     }
                 }
                 Err(e) => {
-                    eprintln!("ssh transcript: read_delta {} failed: {e}", path.display());
+                    tracing::warn!(err = %e, path = %path.display(), "ssh_transcript: read_delta failed");
                 }
             }
         }

--- a/src-tauri/src/ssh/watcher.rs
+++ b/src-tauri/src/ssh/watcher.rs
@@ -109,7 +109,7 @@ pub fn start(
     // Extend the asset protocol scope once, at watch start, to cover this watch's cache dir.
     if let Ok(cache_dir) = cache::cache_root(&app, &watch_id) {
         if let Err(e) = app.asset_protocol_scope().allow_directory(&cache_dir, true) {
-            eprintln!("warn: extending asset scope for {} failed: {e}", cache_dir.display());
+            tracing::warn!(err = %e, cache_dir = %cache_dir.display(), "ssh_watcher: failed to extend asset protocol scope");
         }
     }
 
@@ -173,6 +173,7 @@ async fn run_loop(
         let sftp = match conn.open_sftp().await {
             Ok(s) => s,
             Err(e) => {
+                tracing::warn!(err = %e, %watch_id, "ssh_watcher: open_sftp failed; entering Reconnecting");
                 set_status_and_maybe_emit(
                     &app,
                     &status,
@@ -192,6 +193,7 @@ async fn run_loop(
             Err(e) => {
                 let msg = e.to_string();
                 if msg.contains("No such file") || msg.contains("not found") {
+                    tracing::warn!(err = %msg, %watch_id, %remote_path, "ssh_watcher: remote path invalid; stopping poll");
                     set_status_and_maybe_emit(
                         &app,
                         &status,
@@ -200,6 +202,7 @@ async fn run_loop(
                     );
                     return; // Stop polling — config is bad. User must edit watch.
                 }
+                tracing::warn!(err = %msg, %watch_id, %remote_path, "ssh_watcher: scan failed; entering Reconnecting");
                 set_status_and_maybe_emit(
                     &app,
                     &status,
@@ -375,7 +378,7 @@ async fn reconcile(
                     };
                     tracked.insert(entry.abs_path.clone(), now_track);
                     if track.emitted {
-                        let _ = app.emit(
+                        if let Err(err) = app.emit(
                             "viz:updated",
                             VizUpdated {
                                 watch_id: watch_id.to_string(),
@@ -383,7 +386,9 @@ async fn reconcile(
                                 mtime: entry.mtime_ms,
                                 size: entry.size,
                             },
-                        );
+                        ) {
+                            tracing::warn!(?err, abs_path = %entry.abs_path, "ssh_watcher: emit viz:updated failed");
+                        }
                         if let Some(item) = state
                             .items
                             .lock()
@@ -412,13 +417,16 @@ async fn reconcile(
         let removed_ok = state.items.lock().remove(&key).is_some();
         if removed_ok {
             mark_history_dirty(state);
-            let _ = app.emit(
+            let abs_path = path.clone();
+            if let Err(err) = app.emit(
                 "viz:gone",
                 VizGone {
                     watch_id: watch_id.to_string(),
                     abs_path: path,
                 },
-            );
+            ) {
+                tracing::warn!(?err, %abs_path, "ssh_watcher: emit viz:gone failed");
+            }
             any_change = true;
         }
     }
@@ -469,7 +477,9 @@ async fn emit_new(
     };
     state.items.lock().insert(key, merged.clone());
     mark_history_dirty(state);
-    let _ = app.emit("viz:new", &merged);
+    if let Err(err) = app.emit("viz:new", &merged) {
+        tracing::warn!(?err, abs_path = %merged.abs_path, "ssh_watcher: emit viz:new failed");
+    }
 
     transcript::try_enrich_now(
         app,
@@ -503,13 +513,15 @@ fn set_status_and_maybe_emit(
     *cur = next;
     drop(cur);
     if let Some(payload) = to_emit {
-        let _ = app.emit(
+        if let Err(err) = app.emit(
             "viz:watch_status",
             WatchStatusEvent {
                 watch_id: watch_id.to_string(),
                 status: payload,
             },
-        );
+        ) {
+            tracing::warn!(?err, %watch_id, "ssh_watcher: emit viz:watch_status failed");
+        }
     }
 }
 

--- a/src-tauri/src/transcript.rs
+++ b/src-tauri/src/transcript.rs
@@ -333,7 +333,14 @@ fn scan_active_jsonls() -> Vec<PathBuf> {
 pub(crate) fn process_line(index: &SharedIndex, line: &str) {
     let envelope: RawEnvelope = match serde_json::from_str(line) {
         Ok(v) => v,
-        Err(_) => return,
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                line_preview = %line.chars().take(120).collect::<String>(),
+                "transcript: malformed JSONL line"
+            );
+            return;
+        }
     };
     let ts_ms = envelope
         .timestamp
@@ -1103,5 +1110,13 @@ mod tests {
         });
         // mtime - ts = 60s > 30s window
         assert!(idx.lookup(60_000, "/tmp/p.png").is_none());
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn process_line_warns_on_malformed_json() {
+        let index = new_index();
+        process_line(&index, "{not json");
+        assert!(logs_contain("transcript: malformed JSONL line"));
     }
 }

--- a/src-tauri/src/transcript.rs
+++ b/src-tauri/src/transcript.rs
@@ -636,7 +636,9 @@ pub(crate) fn enrich_pending_all(app: &AppHandle, state: &Arc<AppState>, index: 
             continue;
         }
         any_enriched = true;
-        let _ = app.emit(
+        let abs_path_for_log = abs_path.clone();
+        let watch_id_for_log = watch_id.clone();
+        if let Err(err) = app.emit(
             "viz:enriched",
             VizEnriched {
                 watch_id,
@@ -646,7 +648,9 @@ pub(crate) fn enrich_pending_all(app: &AppHandle, state: &Arc<AppState>, index: 
                 session_id: hit.session_id,
                 cwd: hit.cwd,
             },
-        );
+        ) {
+            tracing::warn!(?err, watch_id = %watch_id_for_log, abs_path = %abs_path_for_log, "transcript: emit viz:enriched failed (batch)");
+        }
     }
     if any_enriched {
         mark_history_dirty(state);
@@ -681,7 +685,7 @@ pub fn try_enrich_now(
     if mutated {
         mark_history_dirty(state);
     }
-    let _ = app.emit(
+    if let Err(err) = app.emit(
         "viz:enriched",
         VizEnriched {
             watch_id: watch_id.to_string(),
@@ -691,7 +695,9 @@ pub fn try_enrich_now(
             session_id: hit.session_id,
             cwd: hit.cwd,
         },
-    );
+    ) {
+        tracing::warn!(?err, %watch_id, %abs_path, "transcript: emit viz:enriched failed (try_enrich_now)");
+    }
 }
 
 fn parse_iso8601_ms(s: &str) -> Option<i64> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { TopBar } from "./components/TopBar";
 import { FirstRunPicker } from "./components/FirstRunPicker";
 import { prefetchRemoteFile, invalidateRemoteAsset } from "./components/RemoteAssetGate";
 import { useHotkeys } from "./lib/hotkeys";
+import { swallowWithLog } from "./lib/log";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 
 export default function App() {
@@ -79,7 +80,7 @@ export default function App() {
     onToggleFollow: () => {
       toggleFollow();
       const next = useVizStore.getState().followLatest;
-      tauri.setFollowLatest(next).catch(() => {});
+      tauri.setFollowLatest(next).catch(swallowWithLog("App: hotkey toggle setFollowLatest"));
     },
     onToggleFullscreen: () => {
       // Future: actual fullscreen mode. For now: scroll selected into view.
@@ -87,7 +88,7 @@ export default function App() {
     onRevealOnDisk: () => {
       const { selectedId, items } = useVizStore.getState();
       const item = selectedId ? items[selectedId] : null;
-      if (item) revealItemInDir(item.abs_path).catch(() => {});
+      if (item) revealItemInDir(item.abs_path).catch(swallowWithLog("App: hotkey revealItemInDir"));
     },
   });
 

--- a/src/components/ConnectRemoteDialog.tsx
+++ b/src/components/ConnectRemoteDialog.tsx
@@ -12,6 +12,7 @@ import {
   X,
 } from "lucide-react";
 import { tauri } from "../lib/tauri";
+import { swallowWithLog } from "../lib/log";
 import { useVizStore } from "../store/vizStore";
 import type {
   HostKeyChangedInfo,
@@ -69,7 +70,9 @@ export function ConnectRemoteDialog({ onClose }: Props) {
 
   const onForgetRecent = async (r: RecentRemote, e: React.MouseEvent) => {
     e.stopPropagation();
-    await tauri.forgetRecentRemote(r.host, r.user, r.port, r.remote_path).catch(() => {});
+    await tauri
+      .forgetRecentRemote(r.host, r.user, r.port, r.remote_path)
+      .catch(swallowWithLog("ConnectRemoteDialog: forgetRecentRemote"));
     setRecents((prev) =>
       prev.filter(
         (x) =>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -13,6 +13,7 @@ import { useVizStore } from "../store/vizStore";
 import { FollowToggle } from "./FollowToggle";
 import { ConnectRemoteDialog } from "./ConnectRemoteDialog";
 import { tauri } from "../lib/tauri";
+import { swallowWithLog } from "../lib/log";
 import type { Watch, WatchStatus } from "../types";
 
 export function TopBar() {
@@ -47,12 +48,12 @@ export function TopBar() {
 
   const onToggleFollow = () => {
     toggleFollow();
-    tauri.setFollowLatest(!followLatest).catch(() => {});
+    tauri.setFollowLatest(!followLatest).catch(swallowWithLog("TopBar: setFollowLatest"));
   };
 
   const onClear = async () => {
     clearGalleryStore();
-    await tauri.clearGallery().catch(() => {});
+    await tauri.clearGallery().catch(swallowWithLog("TopBar: clearGallery"));
   };
 
   return (
@@ -88,7 +89,7 @@ export function TopBar() {
               // a rescan so any files added since the last scan appear without a restart.
               // No-op for SSH (the SFTP poller handles its own refresh cadence).
               if (next === w.id && w.source.kind === "local") {
-                tauri.rescanWatch(w.id).catch(() => {});
+                tauri.rescanWatch(w.id).catch(swallowWithLog(`TopBar: rescanWatch(${w.id})`));
               }
             }}
             onRemove={async () => {
@@ -224,7 +225,7 @@ function StatusBadge({ status, watchId }: { status: WatchStatus; watchId: string
       {label}
       {canReconnect && (
         <button
-          onClick={() => tauri.reconnectWatch(watchId).catch(() => {})}
+          onClick={() => tauri.reconnectWatch(watchId).catch(swallowWithLog(`TopBar: reconnectWatch(${watchId})`))}
           title="Reconnect"
           className="ml-0.5 opacity-70 hover:opacity-100"
         >

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,0 +1,8 @@
+// Frontend logging helpers. Some Tauri-bound promises are intentionally swallowed
+// (best-effort UI hooks). This wrapper keeps them swallowed but visible in DevTools.
+export function swallowWithLog(context: string) {
+  return (err: unknown) => {
+    // eslint-disable-next-line no-console
+    console.warn(`[swallowed] ${context}`, err);
+  };
+}

--- a/src/viewers/CsvViewer.tsx
+++ b/src/viewers/CsvViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Sheet } from "lucide-react";
 import { convertFileSrc } from "../lib/tauri";
+import { swallowWithLog } from "../lib/log";
 import type { ViewerDefinition, ViewerProps } from "./registry";
 import { DataTable } from "./data/DataTable";
 import type { Column, Dataset } from "./data/types";
@@ -141,7 +142,7 @@ async function readPreviewText(
       chunks.push(decoder.decode(value, { stream: true }));
     }
   } finally {
-    reader.cancel().catch(() => {});
+    reader.cancel().catch(swallowWithLog("CsvViewer: stream reader.cancel"));
   }
 
   let text = chunks.join("") + decoder.decode();


### PR DESCRIPTION
## What
- Add \`tracing\` + \`tracing-subscriber\` + \`tracing-test\` deps. Initialize stderr subscriber at app startup with default filter \`claude_data_viz=info,warn\` (override via \`RUST_LOG\`).
- Backend: convert ~28 swallow sites to \`tracing::warn!\` — \`let _ = app.emit(...)\` becomes \`if let Err(err) = ... { warn!(?err, ...) }\`; untagged \`eprintln!("warn: ...")\` becomes \`tracing::warn!\`. Control flow unchanged.
- Frontend: new \`src/lib/log.ts\` exporting \`swallowWithLog(context)\`. ~8 \`.catch(() => {})\` sites converted to \`.catch(swallowWithLog("..."))\`.

## Why
Many production failure paths were silently swallowed — control flow was correct but failures were invisible. SSH reconnect loops and silently-dropped malformed JSONL lines were the worst offenders. Now everything is greppable in terminal output (\`fs_watcher:\`, \`ssh_watcher:\`, \`[swallowed]\`).

## Env override
- Default: \`claude_data_viz=info,warn\` (third-party crates stay at WARN).
- Verbose: \`RUST_LOG=claude_data_viz=debug\` before \`npm run tauri dev\`.
- \`try_init()\` is idempotent and non-fatal — no boot crash if filter parse fails.

## Test plan
- [x] \`cargo test --lib\`: 41/41 pass. New test \`process_line_warns_on_malformed_json\` uses \`tracing_test::traced_test\` to lock the malformed-JSONL warn message text.
- [x] \`cargo build --lib\`: clean.
- [x] \`npm run build\`: clean.
- [ ] \`npm run tauri dev\`: confirm \`claude-data-viz starting\` appears on stderr at boot.
- [ ] Point ConnectRemote dialog at a bad host: confirm \`ssh_watcher: open_sftp failed\` and status-transition warns appear.
- [ ] Trigger a frontend swallow: confirm \`[swallowed] ConnectRemoteDialog: forgetRecentRemote\` shows in DevTools.

## Files changed (14)
- Backend (10): \`Cargo.{toml,lock}\`, \`lib.rs\`, \`transcript.rs\`, \`fs_watcher.rs\`, \`cap.rs\`, \`commands.rs\`, \`persistence.rs\`, \`ssh/{cache,transcript,watcher}.rs\`
- Frontend (5): \`lib/log.ts\` (new), \`App.tsx\`, \`components/{TopBar,ConnectRemoteDialog}.tsx\`, \`viewers/CsvViewer.tsx\`

## Risk
This PR merges last in the suggested order because it touches the most files and benefits from absorbing the \`eprintln!\` lines added by the unwrap-audit PR. Rebase pain expected to be small (mostly mechanical conflict on the few files that overlap with PR2/PR4/PR7).