### PR TITLE
chore: add CI for cargo test + npm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel in-progress runs on the same ref when a new commit lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: cargo test --lib + npm run build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Tauri 2 system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            libssl-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install npm deps
+        run: npm ci
+
+      - name: cargo test --lib
+        working-directory: src-tauri
+        run: cargo test --lib
+
+      - name: npm run build
+        run: npm run build


### PR DESCRIPTION
## What
Adds \`.github/workflows/ci.yml\`. Runs on every push to \`main\` and every pull request:
1. \`cargo test --lib\` (matches what each of the 7 in-flight worker PRs validated)
2. \`npm run build\` (catches TypeScript regressions and ts-rs binding mismatches)

Cancels in-progress runs on the same ref when a new commit lands. Single \`ubuntu-latest\` job, ~5 min cold / ~2 min warm with the cargo + npm caches.

## Why
The 7 audit-improvement PRs (#5–#11) were each tested in isolation against the \`main\` they branched from. Once you start merging them serially, every later PR is implicitly rebasing onto a different \`main\`. Without CI, that means running the validate-loop manually on your laptop between every merge. With CI, GitHub does it for you and the PR's mergeability becomes a proper gate.

## Design choices

- **\`cargo test --lib\` (not full \`cargo test\`)**: bin/integration tests would pull in the Tauri runtime which has heavier system requirements. Lib tests are what the workers ran and what we actually care about.
- **\`ubuntu-latest\` only, not a matrix**: the README says macOS-first but Linux/Windows "should work." Linux validation catches most regressions. macOS runners cost 10× more on GitHub-hosted; add only if a macOS-specific bug surfaces.
- **No clippy gate yet**: \`cargo clippy --all-targets -- -D warnings\` already fails on main with ~7-12 pre-existing warnings flagged by 4 of the 7 audit workers. Adding it as a hard gate now would mean every PR ships red. Cleanup belongs in a separate PR; once that lands, flip clippy on as a blocking step here.
- **Tauri 2 system deps**: \`libwebkit2gtk-4.1-dev\` etc. — required for the lib to compile against \`tauri = "2"\`.
- **Caching**: \`Swatinem/rust-cache@v2\` for \`src-tauri/\`; \`actions/setup-node@v4\` with \`cache: npm\`. Both honor lockfiles automatically.

## Test plan
This PR self-validates: opening it triggers the workflow on the PR itself. If the workflow file is wrong, the run fails visibly before merge.

## Suggested merge order
**Merge this BEFORE the 7 audit PRs.** That way each subsequent merge benefits from the gate retroactively (each merge to main re-runs CI on top of the new \`main\` head).