### PR TITLE
fix(security): drop allow-same-origin from HTML viewer iframe sandbox

### DIFF
--- a/src/viewers/HtmlViewer.tsx
+++ b/src/viewers/HtmlViewer.tsx
@@ -46,7 +46,7 @@ function HtmlView({ item, displayPath }: ViewerProps) {
       <iframe
         title="viz-html"
         src={`${convertFileSrc(absPath)}?v=${mtime}`}
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-scripts"
         className="w-full h-full bg-white"
       />
     );
@@ -60,7 +60,7 @@ function HtmlView({ item, displayPath }: ViewerProps) {
     <iframe
       title="viz-html"
       srcDoc={srcDoc}
-      sandbox="allow-scripts allow-same-origin"
+      sandbox="allow-scripts"
       className="w-full h-full bg-white"
     />
   );


### PR DESCRIPTION
## Summary
- Closes #22 (P0/CRITICAL): HTML viewer iframe sandbox escape.
- Drops `allow-same-origin` from both `<iframe>` instances in `src/viewers/HtmlViewer.tsx` (the inline `srcDoc` <10MB path and the `convertFileSrc` >10MB fallback). With only `allow-scripts`, the iframe runs in a unique opaque origin and same-origin policy blocks `window.top.__TAURI_INTERNALS__` access.
- Two-character change × two iframes. No other code touched.

## Why
`srcdoc` iframes inherit the embedder's origin per the HTML spec. Combining `allow-same-origin` with `allow-scripts` did NOT force an opaque origin — the iframe ran same-origin with the main webview, so embedded scripts could reach `window.top.__TAURI__` and call any Tauri command. Combined with `csp: null` (#24) and `fs:scope: **` (#23), a malicious HTML file rendered in the gallery could read any file the user could (`~/.ssh/id_rsa`, `~/.aws/credentials`, etc.) and exfiltrate it. Delivery vectors were realistic: any HTML in a watched folder, including SSH-cached files from a compromised remote.

Independently verified at 9/10 confidence via separate code review (see `.gstack/security-reports/2026-04-27-234504.json`, local).

## Related
- #23 — `fs:scope: **` (blast radius). Independent, fix together.
- #24 — `csp: null` (defense-in-depth). Independent, fix together.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` (Vite production build, 1922 modules) passes
- [ ] Render a real Plotly HTML in the app — confirm interactivity (pan, zoom, hover) still works
- [ ] Render a real Bokeh / Altair / Folium HTML — confirm all three render
- [ ] Smoke-test HTML with `<script>parent.postMessage({tauri: typeof window.top?.__TAURI_INTERNALS__}, '*')</script>` — confirm the message reports `'undefined'` (or that the iframe console shows a SecurityError)
- [ ] Render an HTML file from an SSH-cached path (the >10MB `convertFileSrc` branch) — confirm fallback still loads (note: separately blocked today by empty `assetProtocol.scope`, tracked under #23's recommendations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)